### PR TITLE
Use correct response callbacks

### DIFF
--- a/sails.io.backbone.js
+++ b/sails.io.backbone.js
@@ -264,8 +264,10 @@
 
 		// Send a simulated HTTP request to Sails via Socket.io
 		var simulatedXHR = 
-			socket.request(url, params, function serverResponded () {
-				var isSuccess = status >= 200 && status < 300 || status === 304;
+			socket.request(url, params, function serverResponded (body, response) {
+				var isSuccess = response.statusCode >= 200
+					&& response.statusCode < 300
+					|| response.statusCode === 304;
 				
 				if (isSuccess) {
 					(options.success || function(){}).apply(this, arguments);

--- a/sails.io.backbone.js
+++ b/sails.io.backbone.js
@@ -264,8 +264,16 @@
 
 		// Send a simulated HTTP request to Sails via Socket.io
 		var simulatedXHR = 
-			socket.request(url, params, function serverResponded ( response ) {
-				if (options.success) options.success(response);
+			socket.request(url, params, function serverResponded () {
+				var isSuccess = status >= 200 && status < 300 || status === 304;
+				
+				if (isSuccess) {
+					(options.success || function(){}).apply(this, arguments);
+				} else {
+					(options.error || function(){}).apply(this, arguments);
+				}
+				
+				(options.complete || function(){}).apply(this, arguments);
 			}, verb);
 
 


### PR DESCRIPTION
Previously the `success` callback was called, regardless of the response code that the server actually returned. Additionally, only the body was passed back into the callback, so it would be impossible to actually determine the response code!

This PR uses the same method is success checking that jQuery does ([code](https://github.com/jquery/jquery/blob/master/src/ajax.js#L680)) and calls the appropriate success, error, and complete callback.
