### PR TITLE
Updated backbone-to-sails to be compatible with Sails v0.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,12 +251,16 @@ sending an HTTP request.
 
 
 ###### Listening to the Server
-> i.e. What happens when comet messages arrive?
+> i.e. What happens when messages arrive?
 
 When your Sails publishes a message using `Foo.publish`, the name of
-the socket event is always 'message'. This SDK examines all incoming
-messages from Sails, then triggers a `comet` event on the `Backbone` 
-global.
+the socket event is always the name of the Model - in this case 'foo'.
+If you provide socket callbacks, you'll receive messages about the
+model Foo on the 'foo' channel. If you don't provide callbacks, all
+incoming messages will be sent to the 'comet' channel.
+
+This SDK examines all incoming messages from Sails, then triggers the 
+appropriate event ('foo' vs. 'comet') on the `Backbone` global.
 
 
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 backbone-to-sails
 =================
 
-Backbone SDK for communicating with Sails.js over Socket.io.
+Backbone SDK for communicating with Sails.js over Socket.io (Updated for Sails v0.10).
 
 
 ### Background
@@ -25,7 +25,7 @@ That's it!
 
 #### Sending messages to the server (i.e. ajax)
 There is no special usage for sending requests-- everything works just like you would normally with Backbone via HTTP.
-Just be sure and wait for the socket to be connected first!  Otherwise you'll see an ugly, but hopefully descriptive) error message.
+Just make sure that 1.) the socket has connected first (otherwise you'll see an ugly, but hopefully descriptive, error message.) and 2.) the initBackbone callback has successfully completed.
 
 For example:
 
@@ -33,44 +33,64 @@ For example:
 
 socket.on('connect', function socketReady() {
 
-	var Twinkies = Backbone.Collection.extend({ url: '/twinkie '});
-	var someTwinkies = new Twinkies();
+    initBackbone(function() {
+        // Safe to start working with Backbone.
 
-	someTwinkies.fetch();
+        var Twinkies = Backbone.Collection.extend({ url: '/twinkie '});
+        var someTwinkies = new Twinkies();
 
-	someTwinkies.on('sync', function () {
-		var myTwinkie = someTwinkies.get(1);
-		myTwinkie.wasEaten = true;
-		myTwinkie.save();
+        someTwinkies.fetch();
 
-		// If there are two many twinkies, throw one away... :\
-		// What if they're multiplying?!
-		if (someTwinkies.length > 5) {
-			var suspiciousTwinkie = someTwinkies.get(2);
-			suspiciousTwinkie.destroy();
-		}
-	});
-})
+        someTwinkies.on('sync', function () {
+            var myTwinkie = someTwinkies.get(1);
+            myTwinkie.wasEaten = true;
+            myTwinkie.save();
+
+            // If there are two many twinkies, throw one away... :\
+            // What if they're multiplying?!
+            if (someTwinkies.length > 5) {
+                var suspiciousTwinkie = someTwinkies.get(2);
+                suspiciousTwinkie.destroy();
+            }
+        });
+    });
+
+});
 ```
 
 #### Receiving messages from the server (i.e. comet)
 
-This SDK adds a `comet` event to the global `Backbone` object:
+The primary way to receive messages is to register a socket callback for your model as Backbone is initializing.
+Note that providing callbacks is OPTIONAL. If you don't provide any then all incoming messages will be directed to Backbone.on('comet', ...)
 
 ```javascript
-Backbone.on('comet', function ( message ) {
-	
-	// You'll want to do different stuff depending on what's in `message`.
+io.socket.on('connect', function socketReady() {
+  initBackbone({
+    twinkie : function(msg)
+    {
+      Backbone.trigger('twinkie', msg);
+    }
+  },
+  function() {
+    // Send off msg to server...
+  });
+})
 
-	// The structure of `message` is very important.  It can vary, depending on
-	// how you choose to implement your backend, but it should always be an object.
-	//
-	// Currently in Sails v0.9.x, if you are using publishCreate(), publishUpdate(), etc. 
-	// the top-level of message has a predefined format.
-	//
-	// In Sails v0.10, the format of `message` will be completely up to you.
+Backbone.on('twinkie', function ( message ) {
+    
+    // You'll want to do different stuff depending on what's in `message`.
+
+    // The structure of `message` is very important.  It can vary, depending on
+    // how you choose to implement your backend, but it should always be an object.
+    //
+    // In Sails v0.9.x, if you are using publishCreate(), publishUpdate(), etc. 
+    // the top-level of message has a predefined format.
+    //
+    // In Sails v0.10, the format of `message` will be completely up to you.
 })`
 ```
+
+This SDK also adds a `comet` event to the global `Backbone` object (mostly for backwards compatability with Sails v0.9.x).
 
 
 #### Using Basic Pubsub with Sails / Backbone
@@ -106,7 +126,7 @@ socket.get('/user/subscribe', { id: 7 }, function (response) {
   // cool now we're subscribed to the twinkie #7.
   // That means we can receive comet events whenever the server publishes anything to twinkie #7!
   
-  Backbone.on('comet', function ( message ) {
+  Backbone.on('twinkie', function ( message ) {
     console.log('Got the latest on our twinkie:', message);
   });
 });
@@ -120,67 +140,75 @@ The built-in API blueprints in Sails automatically manage publish and subscribe 
 
 ```javascript
 
-// Define our collection
-var Twinkies = Backbone.Collection.extend({ url: '/twinkie '});
-
-// Instantiate our collection
-var someTwinkies = new Twinkies();
+var Twinkies;
+var someTwinkies;
 
 socket.on('connect', function socketReady() {
 
-	// Initiate the first fetch of twinkies
-	// Since we're using the Sails blueprints, we'll also be subscribed 
-	// to each of the twinkies that are returned, as well as the Twinkie class room itself.
-	someTwinkies.fetch();
+    initBackbone({
+            twinkie : function(msg)
+            {
+              Backbone.trigger('twinkie', msg);
+            }
+        },    
+        function() {
 
-	someTwinkies.on('sync', function () {
-		var myTwinkie = someTwinkies.get(1);
-		myTwinkie.wasEaten = true;
-		
-		// Updates the twinkie
-		//
-		// And since we're using blueprints, publishes a message about the update 
-		// to anyone subscribed to the twinkie.
-		//
-		// This also works if this save() resulted in a create-- it just uses the class room
-		// instead of the instance room.  See the Sails docs for more on that-- it's going 
-		// to change in v0.10.
-		myTwinkie.save();
+        // Define our collection
+        Twinkies = Backbone.Collection.extend({ url: '/twinkie '});
 
-		// If there are two many twinkies, throw one away... :\
-		// What if they're multiplying?!
-		if (someTwinkies.length > 5) {
-			var suspiciousTwinkie = someTwinkies.get(2);
-			
-			// Destroys the suspcious twinkie
-			// And since we're using blueprints, it also unsubscribes us from the twinkie,
-			// which means we won't hear any future updates about it
-			// (not that there should be any-- this is mainly for efficiency)
-			//
-			// The blueprints also publishing a message indicating that the twinkie 
-			// was deleted so that any other sockets subscribed can update their UI 
-			// accordingly.
-			suspiciousTwinkie.destroy();
-		}
-	});
+        // Instantiate our collection
+        someTwinkies = new Twinkies();
+
+        // Initiate the first fetch of twinkies
+        // Since we're using the Sails blueprints, we'll also be subscribed 
+        // to each of the twinkies that are returned, as well as the Twinkie class room itself.
+        someTwinkies.fetch();
+
+        someTwinkies.on('sync', function () {
+            var myTwinkie = someTwinkies.get(1);
+            myTwinkie.wasEaten = true;
+            
+            // Updates the twinkie
+            //
+            // And since we're using blueprints, publishes a message about the update 
+            // to anyone subscribed to the twinkie.
+            //
+            // This also works if this save() resulted in a create-- it just uses the class room
+            // instead of the instance room.  See the Sails docs for more on that-- it's going 
+            // to change in v0.10.
+            myTwinkie.save();
+
+            // If there are two many twinkies, throw one away... :\
+            // What if they're multiplying?!
+            if (someTwinkies.length > 5) {
+                var suspiciousTwinkie = someTwinkies.get(2);
+                
+                // Destroys the suspcious twinkie
+                // And since we're using blueprints, it also unsubscribes us from the twinkie,
+                // which means we won't hear any future updates about it
+                // (not that there should be any-- this is mainly for efficiency)
+                //
+                // The blueprints also publishing a message indicating that the twinkie 
+                // was deleted so that any other sockets subscribed can update their UI 
+                // accordingly.
+                suspiciousTwinkie.destroy();
+            }
+        });
+    });
+
 });
 
 
 // Listen for updates from the server
-Backbone.on('comet', function ( message ) {
-	
-	if ( message.model !== 'twinkie' ) {
-		console.error(
-			'Unrecognized comet message received from server-- ' +
-			'I only know how to handle Twinkies!!!'
-		);
-	}
-	
-	switch (message.method) {
-		case 'create': Twinkies.add(message.data); break;
-		case 'update': Twinkies.get(message.id).set(message.changes); break;
-		case 'destroy': Twinkies.remove(Twinkes.get(message.id)); break;
-	}
+Backbone.on('twinkie', function ( message ) {
+    
+    switch(message.verb)
+    {
+        case 'created' : Twinkies.add(message.data); break;
+        case 'updated' : Twinkies.get(message.id).set(message.changes); break;
+        case 'destroy' : Twinkies.remove(Twinkes.get(message.id)); break;
+    }
+    
 })`
 ```
 
@@ -235,18 +263,18 @@ global.
 
 ## Roadmap
 
- +	Build `sails.io.$.js` as a replacement for `sails.io.js` and make it a dependency of this library.  This allows us to do a better job at simulating an XHR object, and should make it possible for other folks to rapidly integrate other jQuery-dependent frameworks as needed.
+ +  Build `sails.io.$.js` as a replacement for `sails.io.js` and make it a dependency of this library.  This allows us to do a better job at simulating an XHR object, and should make it possible for other folks to rapidly integrate other jQuery-dependent frameworks as needed.
 
- +	Built-in auto-synchronization for Backbone.Collection and Backbone.Models, accomplished by expecting a standard CRUD-compatible format in the published messages from the server.  Figuring out that format, and making it reasonably configurable, is the real challenge here.
+ +  Built-in auto-synchronization for Backbone.Collection and Backbone.Models, accomplished by expecting a standard CRUD-compatible format in the published messages from the server.  Figuring out that format, and making it reasonably configurable, is the real challenge here.
 
- +	Ability to pass in a connected socket as an option to fetch/save/etc. as an alternative to stuffing it in a conventional place (i.e. `window.socket`, `Backbone.socket`, etc.)
+ +  Ability to pass in a connected socket as an option to fetch/save/etc. as an alternative to stuffing it in a conventional place (i.e. `window.socket`, `Backbone.socket`, etc.)
 
- +	If Backbone tries to talk to the server and the socket is missing or disconnected, fall back to `$.ajax`.  Should be configurable, with at least three distinct possibilities:
- 	+ Throw a fatal error .
- 	+ Fall back to `$.ajax`, but log a warning.
- 	+ Fall back to `$.ajax` silently (production)
+ +  If Backbone tries to talk to the server and the socket is missing or disconnected, fall back to `$.ajax`.  Should be configurable, with at least three distinct possibilities:
+    + Throw a fatal error .
+    + Fall back to `$.ajax`, but log a warning.
+    + Fall back to `$.ajax` silently (production)
 
- +	Somewhere (but probably in the aforementioned `sails.io.$.js` or `sails.io.js`) create a queue which tracks requests intended for the server that were sent before the socket connects.  If the queue gets too large, or the socket hasn't connected after 10-15 seconds, give up and release the simulated XHR objects with errors explaining the situation.  This lets us ignore connection/disconnection logic, which should dramatically simplify things for beginners.
+ +  Somewhere (but probably in the aforementioned `sails.io.$.js` or `sails.io.js`) create a queue which tracks requests intended for the server that were sent before the socket connects.  If the queue gets too large, or the socket hasn't connected after 10-15 seconds, give up and release the simulated XHR objects with errors explaining the situation.  This lets us ignore connection/disconnection logic, which should dramatically simplify things for beginners.
 
 ## License
 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "backbone-to-sails",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "homepage": "https://github.com/mikermcneil/backbone-to-sails",
   "authors": [
     "Mike McNeil <@mikermcneil>"

--- a/sails.io.backbone.js
+++ b/sails.io.backbone.js
@@ -12,321 +12,317 @@
  * MIT Licensed
  */
 
-(function () {
-
-
-	// The active `socket`
-	var socket;
-
-
-
-	// Also keep track of where it came from
-	var socketSrc;
-
-
-
-	// Used to simplify app-level connection logic-- i.e. so you don't
-	// have to wait for the socket to be connected to start trying to 
-	// synchronize data.
-	var requestQueue = [];
-
-
-
-	// A `setTimeout` that, if necessary, is used to check if the socket
-	// is ready yet (polls).
-	var socketTimer;
-
-
-
-	/**
-	 * _acquireSocket()
-	 *
-	 * Grab hold of our active socket object, set it on `socket` closure variable above.
-	 * (if your connected socket exists on a non-standard variable, change here)
-	 *
-	 * @api private
-	 */
-	var _acquireSocket = function ( ) {
-		if (socket) return;
-
-		if (Backbone.socket) {
-			socket = Backbone.socket;
-			socketSrc = '`Backbone.socket`';
-		}
-		else if (window.socket) {
-			socket = window.socket;
-			socketSrc = '`window.socket`';
-		}
-
-		// The first time a socket is acquired, bind comet listener
-		if (socket) _bindCometListener();
-	};
-
-
-
-	/**
-	 * Checks if the socket is ready- if so, runs the request queue.
-	 * If not, sets the timer again.
-	 */
-	var _keepTryingToRunRequestQueue = function ( ) {
-		clearTimeout(socketTimer);
-
-		// Check if socket is connected (synchronous)
-		var socketIsConnected = socket.socket && socket.socket.connected;
-
-
-		if (socketIsConnected) {
-			
-			// Run the request queue
-			_.each(requestQueue, function (request) {
-				Backbone.sync(request.method, request.model, request.options);
-			});
-		}
-		else {
-
-			// Reset the timer
-			socketTimer = setTimeout(_keepTryingToRunRequestQueue, 250);
-
-			// TODO:
-			// After a configurable period of time, if the socket has still not connected,
-			// throw an error, since the `socket` might be improperly configured.
-
-			// throw new Error(
-			// 	'\n' +
-			// 	'Backbone is trying to communicate with the Sails server using '+ socketSrc +',\n'+
-			// 	'but its `connected` property is still set to false.\n' +
-			// 	'But maybe Socket.io just hasn\'t finished connecting yet?\n' +
-			// 	'\n' +
-			// 	'You might check to be sure you\'re waiting for `socket.on(\'connect\')`\n' +
-			// 	'before using sync methods on your Backbone models and collections.'
-			// );
-		}
-	};
-
-
-
-	// Set up `async.until`-esque mechanism which will attempt to acquire a socket.
-	var attempts = 0,
-		maxAttempts = 3,
-		interval = 1500,
-		initialInterval = 250;
-
-
-
-	var _attemptToAcquireSocket = function () {
-		if ( socket ) return;
-		attempts++;
-		_acquireSocket();
-		if (attempts >= maxAttempts) return;
-		setTimeout(_attemptToAcquireSocket, interval);
-	};
-
-
-
-	// Attempt to acquire the socket more quickly the first time,
-	// in case the user is on a fast connection and it's available.
-	setTimeout(_attemptToAcquireSocket, initialInterval);
-
-
-
-
-
-
-
-	/**
-	 * Backbone.on('comet', ...)
-	 *
-	 * Since Backbone is already a listener (extends Backbone.Events)
-	 * all we have to do is trigger the event on the Backbone global when
-	 * we receive a new message from the server.
-	 * 
-	 * I realize this doesn't do a whole lot right now-- that's ok.
-	 * Let's start light and layer on additional functionality carefully.
-	 */
-	var _bindCometListener = function socketAcquiredForFirstTime () {
-		socket.on('message', function cometMessageReceived (message) {
-			Backbone.trigger('comet', message);
-		});
-	};
-
-
-
-
-
-
-	/**
-	 * # Backbone.sync
-	 *
-	 * Replaces default Backbone.sync function with socket.io transport
-	 *
-	 * @param {String} method
-	 * @param {Backbone.Model|Backbone.Collection} model
-	 * @param {Object} options
-	 *
-	 * @name sync
-	 */
-	Backbone.sync = function (method, model, options) {
-
-		// Clone options to avoid smashing anything unexpected
-		options = _.extend({}, options);
-
-
-
-
-		// If socket is not defined yet, try to grab it again.
-		_acquireSocket();
-
-
-
-		// Handle missing socket
-		if (!socket) {
-			throw new Error(
-				'\n' +
-				'Backbone cannot find a suitable `socket` object.\n' +
-				'This SDK expects the active socket to be located at `window.socket`, '+
-				'`Backbone.socket` or the `socket` property\n' +
-				'of the Backbone model or collection attempting to communicate w/ the server.\n'
-			);
-		}
-
-
-
-		// Ensures the socket is connected and able to communicate w/ the server.
-		// 
-		var socketIsConnected = socket.socket && socket.socket.connected;
-		if ( !socketIsConnected ) {
-
-			// If the socket is not connected, the request is queued
-			// (so it can be replayed when the socket comes online.)
-			requestQueue.push({
-				method: method,
-				model: model,
-				options: options
-			});
-
-
-			// If we haven't already, start polling the socket to see if it's ready
-			_keepTryingToRunRequestQueue();
-
-			return;
-		}
-
-
-
-
-		// Get the actual URL (call `.url()` if it's a function)
-		var url;
-		if (options.url) {
-			url = _.result(options, 'url');
-		}
-		else if (model.url) {
-			url = _.result(model, 'url');
-		}
-		// Throw an error when a URL is needed, and none is supplied.
-		// Copied from backbone.js#1558
-		else throw new Error('A "url" property or function must be specified');
-
-
-
-		// Build parameters to send to the server
-		var params = {};
-
-		if ( !options.data && model ) {
-			params = options.attrs || model.toJSON(options) || {};
-		}
-
-		if (options.patch === true && _.isObject(options.data) && options.data.id === null && model) {
-			params.id = model.id;
-		}
-		
-		if (_.isObject(options.data)) {
-			_(params).extend(options.data);
-		}
-
-
-		// Map Backbone's concept of CRUD methods to HTTP verbs
-		var verb;
-		switch (method) {
-			case 'create':
-				verb = 'post';
-				break;
-			case 'read':
-				verb = 'get';
-				break;
-			case 'update':
-				verb = 'put';
-				break;
-			default:
-				verb = method;
-		}
-
-
-
-		// Send a simulated HTTP request to Sails via Socket.io
-		var simulatedXHR = 
-			socket.request(url, params, function serverResponded ( response ) {
-				if (options.success) options.success(response);
-			}, verb);
-
-
-
-		// Trigget the `request` event on the Backbone model
-    model.trigger('request', model, simulatedXHR, options);
-
-
-    
-		return simulatedXHR;
-	};
-
-
-
-
-
-
-		
-
-
-
-
-	/**
-	 * TODO:
-	 * Replace sails.io.js with `jQuery-to-sails.js`, which can be a prerequisite of 
-	 * this SDK.
-	 *
-	 * Will allow for better client-side error handling, proper simulation of $.ajax,
-	 * easier client-side support of headers, and overall a better experience.
-	 */
-	/*
-	var simulatedXHR = $.Deferred();
-
-
-
-	// Send a simulated HTTP request to Sails via Socket.io
-	io.emit(verb, params, function serverResponded (err, response) {
-		if (err) {
-			if (options.error) options.error(err);
-			simulatedXHR.reject();
-			return;
-		}
-
-		if (options.success) options.success(response);
-		simulatedXHR.resolve();
-	});
-
-
-
-	var promise = simulatedXHR.promise();
-
-
-
-	// Trigger the model's `request` event
-	model.trigger('request', model, promise, options);
-
-
-
-	// Return a promise to allow chaining of sync methods.
-	return promise;
-	*/
-
-
-})();
+ (function (window) {
+    // The active `socket`
+    var socket;
+
+    // Also keep track of where it came from
+    var socketSrc;
+
+    // Used to simplify app-level connection logic-- i.e. so you don't
+    // have to wait for the socket to be connected to start trying to
+    // synchronize data.
+    var requestQueue = [];
+
+    // A `setTimeout` that, if necessary, is used to check if the socket
+    // is ready yet (polls).
+    var socketTimer;
+
+    /**
+     * _acquireSocket()
+     *
+     * Grab hold of our active socket object, set it on `socket` closure variable above.
+     * (if your connected socket exists on a non-standard variable, change here)
+     *
+     * @api private
+     */
+     var _acquireSocket = function (identities) {
+        if (socket) return;
+
+        if (Backbone.socket) {
+            socket = Backbone.socket;
+            socketSrc = '`Backbone.socket`';
+        }
+        else if (window.io.socket) {
+            socket = window.io.socket;
+            socketSrc = '`window.io.socket`';
+        }
+
+        // The first time a socket is acquired, bind comet listener
+        if (socket) _bindCometListener(identities);
+    };
+
+    /**
+     * Checks if the socket is ready- if so, runs the request queue.
+     * If not, sets the timer again.
+     */
+     var _keepTryingToRunRequestQueue = function ( ) {
+        clearTimeout(socketTimer);
+
+        // Check if socket is connected (synchronous)
+        var socketIsConnected = socket.socket && socket.socket.connected;
+
+        if (socketIsConnected) {
+            // Run the request queue
+            _.each(requestQueue, function (request) {
+                Backbone.sync(request.method, request.model, request.options);
+            });
+        }
+        else {
+            // Reset the timer
+            socketTimer = setTimeout(_keepTryingToRunRequestQueue, 250);
+
+            // TODO:
+            // After a configurable period of time, if the socket has still not connected,
+            // throw an error, since the `socket` might be improperly configured.
+
+            // throw new Error(
+            //  '\n' +
+            //  'Backbone is trying to communicate with the Sails server using '+ socketSrc +',\n'+
+            //  'but its `connected` property is still set to false.\n' +
+            //  'But maybe Socket.io just hasn\'t finished connecting yet?\n' +
+            //  '\n' +
+            //  'You might check to be sure you\'re waiting for `socket.on(\'connect\')`\n' +
+            //  'before using sync methods on your Backbone models and collections.'
+            // );
+}
+};
+
+    // Set up `async.until`-esque mechanism which will attempt to acquire a socket.
+    var attempts = 0,
+    maxAttempts = 3,
+    interval = 1500,
+    initialInterval = 250;
+
+    var _attemptToAcquireSocket = function () {
+        if ( socket ) return;
+        attempts++;
+        _acquireSocket();
+        if (attempts >= maxAttempts) return;
+        setTimeout(_attemptToAcquireSocket, interval);
+    };
+
+    /**
+     * initBackbone
+     *
+     * Called from the main app to start Backbone. Optionally accepts an object of
+     * identitiey (Model names) callback functions to bind to corresponding comet events.
+     *
+     * @param {Object|Function} arg1 - Either a non-empty object of identity (Model name) callback
+     *                                 functions, or a callback function for the main app.
+     * @param {Function} [arg2] - A callback function for the main app.
+     *
+     */
+     window.initBackbone = function(arg1, arg2)
+     {
+        // If both an object and callback function are passed in.
+        if(arg1 && typeof arg1 === "object" && arg2 && _isFunction(arg2))
+        {
+            this._identities = arg1;
+            this._cb = arg2;
+        }
+        // If just a callback is passed in.
+        else if(_isFunction(arg1))
+        {
+            this._identities = {};
+            this._cb = arg1;
+        }
+        else
+        {
+            console.log('Error in sails.io.backbone.js: A callback function must be passed in to initBackbone()');
+            console.log('Usage: initBackbone([OBJECT_OF_IDENTITY_CALLBACK_FUNCTIONS], CALLBACK_TO_MAIN_APP)');
+            return;
+        }
+
+        // Attempt to acquire the socket more quickly the first time,
+        // in case the user is on a fast connection and it's available.
+        setTimeout(_attemptToAcquireSocket, initialInterval);
+    }
+
+    /**
+     * Backbone.on('comet', ...)
+     *
+     * Since Backbone is already a listener (extends Backbone.Events)
+     * all we have to do is trigger the event on the Backbone global when
+     * we receive a new message from the server.
+     *
+     * I realize this doesn't do a whole lot right now-- that's ok.
+     * Let's start light and layer on additional functionality carefully.
+     */
+     var _bindCometListener = function socketAcquiredForFirstTime () {
+
+        // Do we have any identities to listen to?
+        var identSize = 0;
+        for(var i in this._identities)
+        {
+            if(this._identities.hasOwnProperty(i))
+            {
+                identSize++;
+            }
+        }
+
+        if(identSize > 0)
+        {
+            for(var i in this._identities)
+            {
+                if(this._identities.hasOwnProperty(i))
+                {
+                    socket.on(i, this._identities[i]);
+                    console.log('Registered ' + i + ' identity.');
+                }
+            }
+        }
+        else
+        {
+            socket.on('message', function cometMessageReceived (message) {
+                Backbone.trigger('comet', message);
+            });
+            console.log('sails.io.backbone.js: No identities provided, registering generic "message" identity.');
+        }
+
+        // Call the main app; Backbone has initialized correctly.
+        this._cb();
+    };
+
+    /**
+     * # Backbone.sync
+     *
+     * Replaces default Backbone.sync function with socket.io transport
+     *
+     * @param {String} method
+     * @param {Backbone.Model|Backbone.Collection} model
+     * @param {Object} options
+     *
+     * @name sync
+     */
+     Backbone.sync = function (method, model, options) {
+
+        // Clone options to avoid smashing anything unexpected
+        options = _.extend({}, options);
+
+        // If socket is not defined yet, try to grab it again.
+        _acquireSocket();
+
+        // Handle missing socket
+        if (!socket) {
+            throw new Error(
+                '\n' +
+                'Backbone cannot find a suitable `socket` object.\n' +
+                'This SDK expects the active socket to be located at `window.io.socket`, '+
+                '`Backbone.socket` or the `socket` property\n' +
+                'of the Backbone model or collection attempting to communicate w/ the server.\n'
+                );
+        }
+
+        // Ensures the socket is connected and able to communicate w/ the server.
+        //
+        var socketIsConnected = socket.socket && socket.socket.connected;
+        if ( !socketIsConnected ) {
+
+            // If the socket is not connected, the request is queued
+            // (so it can be replayed when the socket comes online.)
+            requestQueue.push({
+                method: method,
+                model: model,
+                options: options
+            });
+
+            // If we haven't already, start polling the socket to see if it's ready
+            _keepTryingToRunRequestQueue();
+
+            return;
+        }
+
+        // Get the actual URL (call `.url()` if it's a function)
+        var url;
+        if (options.url) {
+            url = _.result(options, 'url');
+        }
+        else if (model.url) {
+            url = _.result(model, 'url');
+        }
+        // Throw an error when a URL is needed, and none is supplied.
+        // Copied from backbone.js#1558
+        else throw new Error('A "url" property or function must be specified');
+
+        // Build parameters to send to the server
+        var params = {};
+
+        if ( !options.data && model ) {
+            params = options.attrs || model.toJSON(options) || {};
+        }
+
+        if (options.patch === true && _.isObject(options.data) && options.data.id === null && model) {
+            params.id = model.id;
+        }
+
+        if (_.isObject(options.data)) {
+            _(params).extend(options.data);
+        }
+
+        // Map Backbone's concept of CRUD methods to HTTP verbs
+        var verb;
+        switch (method) {
+            case 'create':
+            verb = 'post';
+            break;
+            case 'read':
+            verb = 'get';
+            break;
+            case 'update':
+            verb = 'put';
+            break;
+            default:
+            verb = method;
+        }
+
+        // Send a simulated HTTP request to Sails via Socket.io
+        var simulatedXHR =
+        socket.request(url, params, function serverResponded ( response ) {
+            if (options.success) options.success(response);
+        }, verb);
+
+        // Trigget the `request` event on the Backbone model
+        model.trigger('request', model, simulatedXHR, options);
+
+        return simulatedXHR;
+    };
+
+    // Helper function.
+    function _isFunction(functionToCheck) {
+       var getType = {};
+       return functionToCheck && getType.toString.call(functionToCheck) === '[object Function]';
+   }
+
+    /**
+     * TODO:
+     * Replace sails.io.js with `jQuery-to-sails.js`, which can be a prerequisite of
+     * this SDK.
+     *
+     * Will allow for better client-side error handling, proper simulation of $.ajax,
+     * easier client-side support of headers, and overall a better experience.
+     */
+    /*
+    var simulatedXHR = $.Deferred();
+
+    // Send a simulated HTTP request to Sails via Socket.io
+    io.emit(verb, params, function serverResponded (err, response) {
+        if (err) {
+            if (options.error) options.error(err);
+            simulatedXHR.reject();
+            return;
+        }
+
+        if (options.success) options.success(response);
+        simulatedXHR.resolve();
+    });
+
+    var promise = simulatedXHR.promise();
+
+    // Trigger the model's `request` event
+    model.trigger('request', model, promise, options);
+
+    // Return a promise to allow chaining of sync methods.
+    return promise;
+    */
+})(window);


### PR DESCRIPTION
The biggest change was adding the ability to listen to messages sent from a specific Model (as opposed to interpreting all incoming messages in the 'comet' event). For example, to listen for messages from Twinkie:

``` javascript
Backbone.on('twinkie', function ( message ) {
    // Do things with message.
});
```

'comet' messages are still available and are the default if no socket message callbacks are supplied.

The only bit of visible overhead that's been added is the initBackbone() function which must be called AFTER the socket connection is made and BEFORE you begin working with Backbone. Here's an example:

``` javascript
socket.on('connect', function socketReady() {
    initBackbone(function() {
        // Safe to start working with Backbone.
    });
});
```

In order to listen for messages about a specific Model, you pass in an Object as the first argument to initBackbone() that maps Model names with callback functions that trigger a Backbone event:

``` javascript
socket.on('connect', function socketReady() {
    initBackbone({
        twinkie : function(msg)
        {
           Backbone.trigger('twinkie', msg);
        }
    },
    function() {
        // Safe to start working with Backbone.
    });
});
```

It's not the most elegant way to go about it but I haven't found a better way that doesn't rely on generating functions from strings using eval(). For example, it would be possible for initBackbone() to accept an array of event names:

``` javascript
socket.on('connect', function socketReady() {
    initBackbone(['twinkie'], function() {
        // Safe to start working with Backbone.
    });
});
```

which is much easier on the eyes but it would rely on using:

``` javascript
var eventName = "twinkie";
var code = "Backbone.trigger('" + eventName + "', msg);"
var cb = Function('msg', code);
```

in the background. If anyone knows of a better looking way to accomplish this I'd love to hear it. Let me know what you all think!
